### PR TITLE
docs: add .env.example file for contributors

### DIFF
--- a/news_project/.env.example
+++ b/news_project/.env.example
@@ -1,0 +1,4 @@
+SECRET_KEY=your_django_secret_key_here
+NEWS_API_KEY=your_news_api_key_here
+DEBUG=True
+ALLOWED_HOSTS=127.0.0.1,localhost


### PR DESCRIPTION
## 📌 Description
Brief description of what this PR does.
Added a .env.example file to the repository so contributors know exactly which environment variables are required to run 
the project locally without having to read through the entire README.

## 🔗 Related Issue
Closes: #8 


## 🛠 Changes Made
- Added .env.example file to the news_project folder with 
  the following variables:
  - SECRET_KEY
  - NEWS_API_KEY
  - DEBUG
  - ALLOWED_HOSTS

## 📷 Screenshots (if applicable)
<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/6cc45ce7-db2a-45f1-a117-00b088aef189" />



## ✅ Checklist
- [x] I have tested my changes
- [x] My code follows project guidelines
- [x] I have linked the related issue
